### PR TITLE
Add getResource method with generics

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
@@ -40,6 +40,19 @@ public interface ResourceFactory {
             throws PathNotFoundException;
 
     /**
+     * Get a resource from the persistence layer as a particular type
+     *
+     * @param <T> type for the resource
+     * @param transaction The transaction this request is part of.
+     * @param identifier The path or identifier for the resource.
+     * @param clazz class the resource will be cast to
+     * @return The resource.
+     * @throws PathNotFoundException If the identifier cannot be found.
+     */
+    public <T extends FedoraResource> T getResource(final FedoraTransaction transaction, final String identifier,
+            final Class<T> clazz) throws PathNotFoundException;
+
+    /**
      * Create a new container.
      *
      * @param transaction The transaction this request is part of.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -115,6 +115,22 @@ public class ResourceFactoryImpl implements ResourceFactory {
 
     }
 
+    @Override
+    public <T extends FedoraResource> T getResource(final FedoraTransaction transaction, final String identifier,
+            final Class<T> clazz)
+            throws PathNotFoundException {
+        try {
+            final PersistentStorageSession psSession = getSession(transaction);
+            return clazz.cast(psSession.read(identifier));
+        } catch (final PersistentItemNotFoundException e) {
+            throw new PathNotFoundException(e);
+        } catch (final PersistentStorageException e) {
+            // This is a big error, wrap as RepositoryRuntime and send it through.
+            throw new RepositoryRuntimeException(e);
+        }
+
+    }
+
     /**
      * This is probably a bad idea, but for stubbing lets instantiate whatever we need.
      *


### PR DESCRIPTION
Usage would be:
```
ResourceFactory factory = ResourceFactoryImpl.getInstance();
FedoraBinary bin = factory.getResource(null, "what", FedoraBinary.class);
```
Mostly replaces a cast. Theoretically you could use the class to make other decisions in side the method... but will we?