### PR TITLE
resource locking tweaks

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4285,11 +4285,16 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         final var phaser = new Phaser(5);
 
+        final var tx1 = createTransaction();
+        final var tx2 = createTransaction();
+        final var tx3 = createTransaction();
+        final var tx4 = createTransaction();
+
         final RequestThread[] threads = new RequestThread[] {
-                new RequestThread(putObjMethod(first), phaser),
-                new RequestThread(putObjMethod(second), phaser),
-                new RequestThread(putObjMethod(third), phaser),
-                new RequestThread(putObjMethod(fourth), phaser)
+                new RequestThread(addTxTo(putObjMethod(first), tx1), phaser),
+                new RequestThread(addTxTo(putObjMethod(second), tx2), phaser),
+                new RequestThread(addTxTo(putObjMethod(third), tx3), phaser),
+                new RequestThread(addTxTo(putObjMethod(fourth), tx4), phaser)
         };
 
         for (final RequestThread t : threads) {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/lock/ResourceLock.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/lock/ResourceLock.java
@@ -7,6 +7,10 @@ package org.fcrepo.kernel.api.lock;
 
 /**
  * A simple lock with a type, transaction and resource.
+ * <p>
+ * It is essential that implementations of this interface implement {@link Object#equals(Object)} and
+ * {@link Object#hashCode()} so that all locks with the same transaction id and resource id are considered equal.
+ *
  * @author whikloj
  * @since 6.3.1
  */
@@ -35,6 +39,15 @@ public interface ResourceLock {
      * @return true if matches.
      */
     boolean hasLockType(final ResourceLockType lockType);
+
+    /**
+     * If an exclusive lock is requested, returns true only if this lock is exclusive. If non-exclusive is requested,
+     * then true is always returned.
+     *
+     * @param lockType the type of lock requested
+     * @return true if this lock is adequate
+     */
+    boolean isAdequate(final ResourceLockType lockType);
 
     /**
      * @return the transaction ID for this lock.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/ResourceLockImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/ResourceLockImpl.java
@@ -8,15 +8,17 @@ package org.fcrepo.kernel.impl.lock;
 import org.fcrepo.kernel.api.lock.ResourceLock;
 import org.fcrepo.kernel.api.lock.ResourceLockType;
 
+import java.util.Objects;
+
 /**
  * Simple implementation of the complex lock.
  * @author whikloj
  */
 public class ResourceLockImpl implements ResourceLock {
 
-    private String transactionId;
-    private ResourceLockType resourceLockType;
-    private String resourceId;
+    private final String transactionId;
+    private final ResourceLockType resourceLockType;
+    private final String resourceId;
 
     ResourceLockImpl(final ResourceLockType resourceLock, final String txId, final String id) {
         resourceLockType = resourceLock;
@@ -49,6 +51,11 @@ public class ResourceLockImpl implements ResourceLock {
     }
 
     @Override
+    public boolean isAdequate(final ResourceLockType lockType) {
+        return this.resourceLockType == ResourceLockType.EXCLUSIVE || lockType == ResourceLockType.NONEXCLUSIVE;
+    }
+
+    @Override
     public String getTransactionId() {
         return transactionId;
     }
@@ -57,5 +64,22 @@ public class ResourceLockImpl implements ResourceLock {
     public String toString() {
         return String.format("type: %s, txId: %s, resource: %s", resourceLockType, transactionId,
                 resourceId);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ResourceLockImpl that = (ResourceLockImpl) o;
+        return transactionId.equals(that.transactionId) && resourceId.equals(that.resourceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transactionId, resourceId);
     }
 }


### PR DESCRIPTION
@whikloj I was looking into fixing the bug I mentioned yesterday, and while I was in there moved a few more things around.

1. The internal locks are now never explicitly removed. Instead, they are only removed when they expire. This avoids the bug I mentioned yesterday where its technically possible, in very rare cases, for two different transactions to acquire two different internal locks on the same resource id.
2. I added equals and hashCode implementations to the resource lock so that there is only ever one lock on a resource per transaction. This is fine because locks are never released individually.
3. I made a few small tweaks here and there to reduce the number of times lock sets were iterated.